### PR TITLE
Corrige exibição de nome no formulário de pessoas

### DIFF
--- a/resources/views/admin/pages/people/_partials/form.blade.php
+++ b/resources/views/admin/pages/people/_partials/form.blade.php
@@ -810,7 +810,7 @@
                         newHtml += '<span class="time text-white"><i class="fas fa-clock"></i>'
                         newHtml += "Agora</span>"
                         newHtml += '<h3 class="timeline-header bg-info">'
-                        newHtml += '<b>' + retorno[1].name +'</b>'
+                        newHtml += '<b>' + (retorno[1] ? retorno[1].name : 'Sem acampamento') +'</b>'
                         newHtml += '</h3>'
                         newHtml += '<div class="timeline-body">'
                         newHtml += retorno[0].observation


### PR DESCRIPTION
Adiciona verificação para exibir mensagem "Sem acampamento" caso o campo "name" esteja vazio no formulário de pessoas. Isso evita o erro de exibição de campo nulo e melhora a usabilidade do sistema.